### PR TITLE
SC-159576 Upgrade github actions

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "22"
 
       - name: Clone repo
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         name: Setup pnpm cache
         with:
           path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}


### PR DESCRIPTION
source: https://app.shortcut.com/deskpro/story/159576/upgrade-github-actions-to-the-latest-version

This bumps up our dependencies for Github actions which is also what does the deploys. This may help reduce bugs as newer releases often have fixes as well as performance due to optimization gains in newer releases.

This is also public facing so we should do our best to show our best face.