### PR TITLE
[feature] SC-166737/improve app proxy security by restricting where token replacements can go

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -92,12 +92,21 @@
       {
         "url": "https://www.mindmeister.com/oauth2/.*",
         "methods": ["POST"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {
+          "app_id": {
+            "body": ["client_id"]
+          },
+          "client_secret": {
+            "body": ["client_secret"]
+          }
+        }
       },
       {
         "url": "https://www.meistertask.com/api/.*",
         "methods": ["GET", "POST", "PUT", "DELETE"],
-        "timeout": 20
+        "timeout": 20,
+        "settingsInjection": {}
       }
     ]
   }

--- a/manifest.json
+++ b/manifest.json
@@ -94,7 +94,7 @@
         "methods": ["POST"],
         "timeout": 20,
         "settingsInjection": {
-          "app_id": {
+          "client_id": {
             "body": ["client_id"]
           },
           "client_secret": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,16 +20,16 @@ export const placeholders = {
   ACCESS_TOKEN: `[user[${ACCESS_TOKEN_PATH}]]`,
   CLIENT_ID: "__client_id__",
   CLIENT_SECRET: "__client_secret__",
-};
+} as const;
 
 /** MeisterTask */
 export const BASE_URL = "https://www.meistertask.com/api";
 export const AUTH_URL = "https://www.mindmeister.com/oauth2";
 export const HTML_URL = "https://www.meistertask.com/app";
 
-export const SCOPES = ["userinfo.email", "userinfo.profile", "meistertask"];
+export const SCOPES = ["userinfo.email", "userinfo.profile", "meistertask"] as const;
 
 export const DESKPRO_LABEL = {
   name: "Deskpro",
   color: "00aaff",
-};
+} as const;


### PR DESCRIPTION
This pull request introduces improvements to the way configuration and constants are handled for API integrations, focusing on making settings injection and constant definitions more robust and type-safe.

**Configuration and settings injection:**

* Updated the `manifest.json` to support dynamic injection of `app_id` and `client_secret` into the body of OAuth requests for MindMeister, improving flexibility and security for credential management.
* Added explicit empty `settingsInjection` for MeisterTask API requests in `manifest.json`, clarifying that no settings need to be injected for these endpoints.

**Type safety improvements:**

* Added `as const` to several constant objects and arrays in `src/constants.ts` (`placeholders`, `SCOPES`, `DESKPRO_LABEL`), ensuring stricter type inference and preventing accidental mutation.

## Summary by Sourcery

Enhance app proxy security by restricting token replacements to specific OAuth request parameters and strengthen type safety on constants

Enhancements:
- Restrict MindMeister OAuth token replacements to client_id and client_secret in the request body via manifest settingsInjection
- Explicitly define an empty settingsInjection for MeisterTask API endpoints in manifest.json
- Add const assertions to placeholders, SCOPES, and DESKPRO_LABEL constants for stricter type inference